### PR TITLE
fix: escape ampersand in ModInfo

### DIFF
--- a/ModInfo.xml
+++ b/ModInfo.xml
@@ -3,7 +3,7 @@
   <ModInfo>
     <Name value="Vini-UpgradeButton"/>
     <DisplayName value="UPGRADE Button for Items"/>
-    <Author value="Vinicius & ChatGPT"/>
+    <Author value="Vinicius &amp; ChatGPT"/>
     <Description value="Adiciona um botão UPGRADE ao lado de Modificar/Sucatear e aplica lógica de upgrade configurável."/>
     <Version value="2.0.0"/>
   </ModInfo>


### PR DESCRIPTION
## Summary
- escape & in `Author` tag to produce valid XML

## Testing
- `python - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('ModInfo.xml')
print('XML parsed successfully')
PY`
- `dotnet build Source/Vini.Upgrade.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abe48de09c8332ae086dcdab7271a6