### PR TITLE
Respect recipe unlocks for tool upgrades

### DIFF
--- a/Config/upgrade_rules.xml
+++ b/Config/upgrade_rules.xml
@@ -1,10 +1,24 @@
 <upgrade>
-  <!-- Todas as FERRAMENTAS DE PEDRA (Stone tier / T0) -->
-  <rule group="tools_stone" maxQuality="6">
+  <!-- Regras gerais para todas as ferramentas -->
+  <rule group="tools" maxQuality="6">
     <!-- Opcional: limite a quais itens a regra se aplica -->
     <match>
       <item name="meleeToolRepairT0StoneAxe"/>     <!-- Stone Axe -->
+      <item name="meleeToolRepairT0TazasStoneAxe"/>
+      <item name="meleeToolRepairT1ClawHammer"/>
+      <item name="meleeToolRepairT3Nailgun"/>
+      <item name="meleeToolAxeT1IronFireaxe"/>
+      <item name="meleeToolAxeT2SteelAxe"/>
+      <item name="meleeToolPickT1IronPickaxe"/>
+      <item name="meleeToolPickT2SteelPickaxe"/>
       <item name="meleeToolShovelT0StoneShovel"/>  <!-- Stone Shovel -->
+      <item name="meleeToolShovelT1IronShovel"/>
+      <item name="meleeToolShovelT2SteelShovel"/>
+      <item name="meleeToolAxeT3Chainsaw"/>
+      <item name="meleeToolPickT3Auger"/>
+      <item name="meleeToolSalvageT1Wrench"/>
+      <item name="meleeToolSalvageT2Ratchet"/>
+      <item name="meleeToolSalvageT3ImpactDriver"/>
     </match>
 
     <!-- Custos por nível (ajuste à vontade) -->

--- a/Source/UpgradeMod.cs
+++ b/Source/UpgradeMod.cs
@@ -54,6 +54,10 @@ namespace Vini.Upgrade
             if (rule == null)
                 return false;
 
+            // Require that the player knows how to craft this item (gated by books/recipes)
+            if (!IsRecipeKnown(player, item.ItemClass))
+                return false;
+
             if (item.Quality >= rule.MaxQuality)
                 return false;
 
@@ -65,6 +69,21 @@ namespace Vini.Upgrade
             item.Quality = (ushort)newQ;
 
             return true;
+        }
+
+        private static bool IsRecipeKnown(EntityPlayerLocal player, ItemClass itemClass)
+        {
+            // Use reflection to support different game versions
+            var method = player.GetType().GetMethod("IsRecipeKnown", new[] { typeof(ItemClass) });
+            if (method != null)
+                return (bool)method.Invoke(player, new object[] { itemClass });
+
+            method = player.GetType().GetMethod("IsRecipeKnown", new[] { typeof(string) });
+            if (method != null)
+                return (bool)method.Invoke(player, new object[] { itemClass.Name });
+
+            // If the API is unavailable, treat as unknown recipe
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- Require players to know the item's recipe before upgrading, ensuring book unlocks gate upgrades
- Expand tool upgrade rules to cover more tools and use the correct `tools` group

## Testing
- `dotnet build Source/Vini.Upgrade.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf2246c0483329b71005166ef337a