### PR TITLE
Add fallback for upgrade button on latest UI

### DIFF
--- a/Config/Localization.txt
+++ b/Config/Localization.txt
@@ -1,4 +1,4 @@
-Key,File,Type,UsedInMainMenu,NoTranslate,English,Portuguese(Brazil)
+Key,File,Type,UsedInMainMenu,NoTranslate,English,PortugueseBrazil
 xuiUpgrade,ui,Text,True,False,UPGRADE,UPGRADE
 xuiUpgradeTip,ui,Text,True,False,Upgrade this item using configured materials.,Aprimora este item usando os materiais configurados.
 xuiUpgradeOk,ui,Text,True,False,Item upgraded!,Item aprimorado!

--- a/Config/XUi/windows.xml
+++ b/Config/XUi/windows.xml
@@ -1,18 +1,14 @@
 <configs>
-  <!-- Injeta um novo botão ao grupo de botões do item -->
-  <append xpath="/windows/window[@name='item_info']/grid[@name='actions']">
+  <!-- Inject upgrade button into item actions -->
+  <append xpath="/windows/window[@name='itemInfoPanel']//grid[@name='itemActions']">
     <button name="btnUpgrade" width="100" height="32" pos="0,0"
             controller="XUiC_Button" pivot="TopLeft" visual_style="button">
       <rect name="background" />
       <label name="label" text_key="xuiUpgrade" justify="MiddleCenter" />
-      <!-- MUITO IMPORTANTE: ação simbólica que o nosso Harmony intercepta -->
+      <!-- Action name for legacy versions; new versions detect the button id -->
       <on_press value="upgrade_item"/>
       <tooltip text_key="xuiUpgradeTip"/>
     </button>
   </append>
 
-  <!-- Opcional: reordenar o botão para ficar entre Modificar e Sucatear -->
-  <insertAfter xpath="/windows/window[@name='item_info']/grid[@name='actions']/button[@name='btnModify']">
-    <ref xpath="/windows/window[@name='item_info']/grid[@name='actions']/button[@name='btnUpgrade']"/>
-  </insertAfter>
 </configs>


### PR DESCRIPTION
## Summary
- inject upgrade button into new `itemInfoPanel` layout
- handle `OnPress` signatures from newer game versions
- fix localization CSV header

## Testing
- `dotnet build Source/Vini.Upgrade.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf75f72bc8332ac13715e4d90e363