### PR TITLE
Handle XUiController ID via reflection

### DIFF
--- a/Source/UpgradeMod.cs
+++ b/Source/UpgradeMod.cs
@@ -53,7 +53,16 @@ namespace Vini.Upgrade
         static bool Prefix(XUiC_ItemStack __instance, XUiController _sender, int _mouseButton)
         {
             // Some versions pass the pressed button controller instead of a string
-            var id = _sender?.Id ?? _sender?.name;
+            // Access the identifier via reflection to support multiple game versions
+            string? id = null;
+            if (_sender != null)
+            {
+                var t = _sender.GetType();
+                id = t.GetProperty("Id")?.GetValue(_sender) as string
+                     ?? t.GetField("Id")?.GetValue(_sender) as string
+                     ?? t.GetProperty("name")?.GetValue(_sender) as string
+                     ?? t.GetField("name")?.GetValue(_sender) as string;
+            }
             if (id != "btnUpgrade")
                 return true;
 


### PR DESCRIPTION
## Summary
- use reflection to get controller identifier for compatibility with game versions lacking Id/name

## Testing
- `dotnet build Source/Vini.Upgrade.csproj -c Release` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf87ca1bc8332a9b3f503c9eafea2