### PR TITLE
Handle missing ItemStack.OnPress overload in Upgrade mod

### DIFF
--- a/Source/UpgradeMod.cs
+++ b/Source/UpgradeMod.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Xml.Linq;
 using HarmonyLib;
 
@@ -15,9 +16,12 @@ namespace Vini.Upgrade
         }
     }
 
-    [HarmonyPatch(typeof(XUiC_ItemStack), nameof(XUiC_ItemStack.OnPress))]
+    [HarmonyPatch(typeof(XUiC_ItemStack))]
     public static class ItemStack_OnPress
     {
+        static MethodBase? TargetMethod() =>
+            AccessTools.Method(typeof(XUiC_ItemStack), "OnPress", new [] { typeof(string) });
+
         static bool Prefix(XUiC_ItemStack __instance, string _buttonName)
         {
             if (_buttonName != "upgrade_item")
@@ -47,9 +51,12 @@ namespace Vini.Upgrade
     }
 
     // Support for game versions where OnPress no longer provides the command string
-    [HarmonyPatch(typeof(XUiC_ItemStack), "OnPress", new [] { typeof(XUiController), typeof(int) })]
+    [HarmonyPatch(typeof(XUiC_ItemStack))]
     public static class ItemStack_OnPress_New
     {
+        static MethodBase? TargetMethod() =>
+            AccessTools.Method(typeof(XUiC_ItemStack), "OnPress", new [] { typeof(XUiController), typeof(int) });
+
         static bool Prefix(XUiC_ItemStack __instance, XUiController _sender, int _mouseButton)
         {
             // Some versions pass the pressed button controller instead of a string


### PR DESCRIPTION
## Summary
- Prevent Harmony patching errors by only patching `XUiC_ItemStack.OnPress` overloads that exist

## Testing
- `dotnet build Source/Vini.Upgrade.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68abf94170508332b0e6ff30441c68da