### PR TITLE
Handle popup AddItem overload and add Log shim

### DIFF
--- a/Source/Log.cs
+++ b/Source/Log.cs
@@ -1,0 +1,7 @@
+namespace Vini.Upgrade
+{
+    public static class Log
+    {
+        public static void Out(string message) => System.Console.WriteLine(message);
+    }
+}


### PR DESCRIPTION
## Summary
- Use reflection to invoke the popup AddItem method and support multiple signatures
- Add simple Log.Out shim for compatibility

## Testing
- `dotnet build Source/Vini.Upgrade.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abfd33a5b483329790283733306553