### PR TITLE
Prevent upgrade option on non-upgradeable items

### DIFF
--- a/Source/UpgradeActions.cs
+++ b/Source/UpgradeActions.cs
@@ -6,7 +6,14 @@ namespace Vini.Upgrade
     {
         public static bool IsEligibleForUpgrade(ItemStack stack)
         {
-            return stack?.itemValue != null;
+            var item = stack?.itemValue;
+            if (item?.ItemClass == null)
+                return false;
+
+            if (UpgradeConfig.FindTransform(item.ItemClass.Name) != null)
+                return true;
+
+            return UpgradeConfig.FindRuleFor(item) != null;
         }
 
         public static void TryOpenUpgradeUI(XUiController? source, ItemStack stack)


### PR DESCRIPTION
## Summary
- only show the UPGRADE button when an item has a defined upgrade rule or transform

## Testing
- `dotnet build Source/Vini.Upgrade.csproj -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac05a73b9483328b1c98464e61ac4a